### PR TITLE
Improved the political messaging

### DIFF
--- a/source/Common.cpp
+++ b/source/Common.cpp
@@ -121,13 +121,11 @@ namespace Common {
         memset(framebuf, 0, gfxGetFramebufferSize());
         
         draw_text(0x10, 0x020, YELLOW, "Lockpick! by shchmue");
-
-        draw_set_rect(814, 452 + 42 * 0, 450, 42, RGBA8_MAXALPHA(0xe7, 0x00, 0x00));
-        draw_set_rect(814, 452 + 42 * 1, 450, 42, RGBA8_MAXALPHA(0xff, 0x8c, 0x00));
-        draw_set_rect(814, 452 + 42 * 2, 450, 42, RGBA8_MAXALPHA(0xff, 0xef, 0x00));
-        draw_set_rect(814, 452 + 42 * 3, 450, 42, RGBA8_MAXALPHA(0x00, 0x81, 0x1f));
-        draw_set_rect(814, 452 + 42 * 4, 450, 42, RGBA8_MAXALPHA(0x00, 0x44, 0xff));
-        draw_set_rect(814, 452 + 42 * 5, 450, 42, RGBA8_MAXALPHA(0x76, 0x00, 0x89));
+        
+        draw_text(814, 452, RED, "MAKE AMERICA GREAT AGAIN!");
+        
+        draw_text(814, 500, YELLOW, "TRUMP 2020!");
+        draw_text(814, 545, WHITE, "ITS OKAY TO BE WHITE");
 
         if (  !(envIsSyscallHinted(0x60) &&     // svcDebugActiveProcess
                 envIsSyscallHinted(0x63) &&     // svcGetDebugEvent

--- a/source/Common.cpp
+++ b/source/Common.cpp
@@ -125,7 +125,7 @@ namespace Common {
         draw_text(814, 452, RED, "MAKE AMERICA GREAT AGAIN!");
         
         draw_text(814, 500, YELLOW, "TRUMP 2020!");
-        draw_text(814, 545, WHITE, "ITS OKAY TO BE WHITE");
+        draw_text(814, 545, WHITE, "IT'S OKAY TO BE WHITE");
 
         if (  !(envIsSyscallHinted(0x60) &&     // svcDebugActiveProcess
                 envIsSyscallHinted(0x63) &&     // svcGetDebugEvent

--- a/source/Common.hpp
+++ b/source/Common.hpp
@@ -26,6 +26,7 @@
 #define RED     RGBA8_MAXALPHA(0xff, 0, 0)
 #define CYAN    RGBA8_MAXALPHA(0, 0xff, 0xff)
 #define YELLOW  RGBA8_MAXALPHA(0xff, 0xff, 0)
+#define WHITE   RGBA8_MAXALPHA(0xFF, 0xff, 0xFF)
 
 enum {
     Status_fail = 0,


### PR DESCRIPTION
LGBTQ political messages are just too old-fashioned these days. Let's support a group that is really unpopular and speak truth to power. Because it doesn't matter if its hacking children's consoles, we absolutely MUST insert political messages into our home-brew.