### PR TITLE
Makefile: change LIBDIRS order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ LIBS	:= -lnx -lmbedcrypto -lstdc++fs `freetype-config --libs`
 # list of directories containing libraries, this must be the top level containing
 # include and lib
 #---------------------------------------------------------------------------------
-LIBDIRS	:= $(PORTLIBS) $(LIBNX) $(TOPDIR)/source/mbedtls
+LIBDIRS	:= $(TOPDIR)/source/mbedtls $(PORTLIBS) $(LIBNX)
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Your custom build of mbedtls needs to be in front of `PORTLIBS` so it gets picked up if mbedtls from pacman is installed.